### PR TITLE
[feat] CustomButton UI

### DIFF
--- a/MARO/View/OnboardingView.swift
+++ b/MARO/View/OnboardingView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct OnboardingView: View {
-//    @Binding var isFirstLaunching: Bool
+    //    @Binding var isFirstLaunching: Bool
     @State private var selection: Int = 1
     
     var body: some View {
@@ -18,21 +18,29 @@ struct OnboardingView: View {
                 
                 Button { print("Hello I'm pressed!") }
                 label: { Text("건너뛰기") }
-                .opacity(selection == 3 ? 0 : 1)
-
-        }
-        .padding(.bottom, 65)
-        
-        TabView(selection: $selection) {
-            OnboardingFirstPage().tag(1)
-            OnboardingSecondPage().tag(2)
-            OnboardingThirdPage().tag(3)
-        }
-        .tabViewStyle(PageTabViewStyle())
-        
-    }// VStack
+                    .opacity(selection == 3 ? 0 : 1)
+                
+            }
+            .padding(.bottom, 65)
+            
+            TabView(selection: $selection) {
+                OnboardingFirstPage().tag(1)
+                OnboardingSecondPage().tag(2)
+                OnboardingThirdPage().tag(3)
+            }
+            .tabViewStyle(PageTabViewStyle())
+            
+        }// VStack
         .padding(.horizontal, 20)
-}// body
+        .onAppear { setPageIndicatorColor() }
+    }// body
+    
+    // https://stackoverflow.com/questions/62864221/change-tabview-indicator-swiftui
+    func setPageIndicatorColor() {
+      UIPageControl.appearance().currentPageIndicatorTintColor = .black
+      UIPageControl.appearance().pageIndicatorTintColor = UIColor.black.withAlphaComponent(0.2)
+    }
+    
 }// OnboardingView
 
 struct OnboardingView_Previews: PreviewProvider {
@@ -46,11 +54,11 @@ struct OnboardingFirstPage: View {
     var body: some View {
         VStack {
             Text("나의 하루를 위한 하나의 약속을 확인해요")
-
+            
             Spacer()
-
+            
             Image("onboardingImage1")
-
+            
         }// VStack
     }// body
 }// OnboardingFirstPage
@@ -87,20 +95,21 @@ struct OnboardingThirdPage: View {
             
             CustomButton(text: "시작하기") { }
                 .padding(.bottom, 55)
-             
+            
         }// VStack
     }// body
 }// OnboardingThirdPage
 
+// MARK: Reusable CustomButton Sample
 struct CustomButton: View {
     var text: String
     var action: () -> Void
-
+    
     init(text: String, action: @escaping () -> Void) {
         self.text = text
         self.action = action
     }
-
+    
     var body: some View {
         Button {
             action()
@@ -113,6 +122,5 @@ struct CustomButton: View {
                         .foregroundColor(.white)
                 }
         }
-
     }// body
 }//CustomButton

--- a/MARO/View/OnboardingView.swift
+++ b/MARO/View/OnboardingView.swift
@@ -82,15 +82,37 @@ struct OnboardingThirdPage: View {
             Text("나의 하루를 위한 하나의 약속\n마로와 함께해요")
                 .multilineTextAlignment(.center)
                 .padding(.top, 41)
-                .padding(.bottom, 100)
             
             Spacer()
             
-            Button { }
-            label: { Text("시작하기") }
-            
+            CustomButton(text: "시작하기") { }
+                .padding(.bottom, 55)
+             
         }// VStack
     }// body
 }// OnboardingThirdPage
 
+struct CustomButton: View {
+    var text: String
+    var action: () -> Void
 
+    init(text: String, action: @escaping () -> Void) {
+        self.text = text
+        self.action = action
+    }
+
+    var body: some View {
+        Button {
+            action()
+        } label: {
+            RoundedRectangle(cornerRadius: 10)
+                .frame(maxHeight: 56)
+                .overlay {
+                    Text(text)
+                        .font(.headline)
+                        .foregroundColor(.white)
+                }
+        }
+
+    }// body
+}//CustomButton


### PR DESCRIPTION
## 작업 내용 (Content)
- 재사용 가능한 커스텀 버튼 UI 샘플을 구현했습니다.

## 기타 사항 (Etc)
- 온보딩 / 약속 추가 화면에서 사용 가능한 커스텀 버튼의 UI 입니다.
- 버튼 컬러의 경우 메인화면에서 작업한 에셋 병합 이후 변경할 예정입니다.

## Close Issues
- N/A

## 관련 사진(Optional)
<img src="https://user-images.githubusercontent.com/88080251/193440734-c6b0b63c-d900-4105-8150-19cf750f9c5e.png" width="250">